### PR TITLE
Add `clone_registry` option to allow skipping cloning the registry

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -89,25 +89,25 @@ which julia
 julia -e 'using InteractiveUtils; versioninfo()'
 
 
-## update the registry
+if [[ "${BUILDKITE_PLUGIN_JULIA_CLONE_REGISTRY:-true}" == "true" ]]; then
+    echo "--- :julia: Updating the registry"
 
-echo "--- :julia: Updating the registry"
-
-# Occasionally, there are rather large delays (> a few hours) between the time a package is
-# registered in General and propagated to pkg.julialang.org. We can avoid this by manually
-# updating the registry, not using the Julia package servers while doing so:
-# - https://github.com/JuliaLang/Pkg.jl/issues/2011
-# - https://github.com/JuliaRegistries/General/issues/16777
-# - https://github.com/JuliaPackaging/PkgServer.jl/issues/60
-JULIA_PKG_SERVER="" \
-julia -e '
-  using Pkg
-  if VERSION >= v"1.1-"
-    if !isdir(joinpath(DEPOT_PATH[1], "registries", "General"))
-      Pkg.Registry.add("General")
-    else
-      Pkg.Registry.update()
-    end
-  else
-    Pkg.API.update_registry(Pkg.Types.Context())
-  end'
+    # Occasionally, there are rather large delays (> a few hours) between the time a package is
+    # registered in General and propagated to pkg.julialang.org. We can avoid this by manually
+    # updating the registry, not using the Julia package servers while doing so:
+    # - https://github.com/JuliaLang/Pkg.jl/issues/2011
+    # - https://github.com/JuliaRegistries/General/issues/16777
+    # - https://github.com/JuliaPackaging/PkgServer.jl/issues/60
+    JULIA_PKG_SERVER="" \
+    julia -e '
+      using Pkg
+      if VERSION >= v"1.1-"
+        if !isdir(joinpath(DEPOT_PATH[1], "registries", "General"))
+          Pkg.Registry.add("General")
+        else
+          Pkg.Registry.update()
+        end
+      else
+        Pkg.API.update_registry(Pkg.Types.Context())
+      end'
+fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -6,4 +6,6 @@ configuration:
   properties:
     version:
       type: string
+    clone_registry:
+      type: boolean
   additionalProperties: false


### PR DESCRIPTION
Some users may want to use the PkgServer to get their registry