### PR TITLE
Fix `unpack_dest` using the wrong variable

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -129,7 +129,7 @@ post_dl_mtime=$(stat -c %y "${tarball_path}" 2>/dev/null)
 # We unpack into another location within our cache directory, then add
 # it to the path.
 unpack_dest=${CACHE_DIR}/julia_installs/julia-${release}-${rarch}
-echo "Installing to ${unpack_dest}"
+echo "Installing location: ${unpack_dest}"
 if [[ "${orig_mtime}" != "${post_dl_mtime}" ]]; then
     echo "New installation detected, unpacking!"
     rm -rf "${unpack_dest}"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -128,7 +128,8 @@ post_dl_mtime=$(stat -c %y "${tarball_path}" 2>/dev/null)
 # If the download actually touched the file, we're going to unpack it
 # We unpack into another location within our cache directory, then add
 # it to the path.
-unpack_dest=${CACHE_DIR}/julia_installs/julia-${JULIA_VERSION}-${rarch}
+unpack_dest=${CACHE_DIR}/julia_installs/julia-${release}-${rarch}
+echo "Installing to ${unpack_dest}"
 if [[ "${orig_mtime}" != "${post_dl_mtime}" ]]; then
     echo "New installation detected, unpacking!"
     rm -rf "${unpack_dest}"


### PR DESCRIPTION
We were using `${JULIA_VERSION}` which can be things like `1`, when we should have been using the concretized `${release}`.