### PR TITLE
A first attempt at cleaning up the cache when it gets too large

### DIFF
--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -4,23 +4,37 @@ shopt -s extglob
 
 CACHE_DIR=${BUILDKITE_PLUGIN_JULIA_CACHE_DIR:-${HOME}/.cache/julia-buildkite-plugin}
 
-### Step 1: Remove any code coverage files in the `julia_installs directory.
-### Once JuliaLang/julia#26573 has been fixed, this should no longer be necessary.
+echo "--- :broom: Performing clean-up"
 
-find $(CACHE_DIR)/julia_installs -name "*.jl.*.cov" -type f -delete
 
-### Step 2: Run `Pkg.gc` to try to reduce the size of the cache.
+### Step 1: Remove any code coverage files
 
-echo "Running Pkg.gc"
+echo "Removing coverage files"
+
+# Once JuliaLang/julia#26573 has been fixed, this should no longer be necessary.
+find "${CACHE_DIR}"/julia_installs -name "*.jl.*.cov" -type f -delete
+
+# Some packages check coverage files in, so only remove writable ones
+if [[ "${BUILDKITE_PLUGIN_JULIA_ISOLATED_DEPOT:-true}" == "true" ]]; then
+    find "${JULIA_DEPOT_PATH}"/packages -name "*.jl.*.cov" -type f -writable -delete
+fi
+
+
+### Step 2: Run `Pkg.gc` to try to reduce the size of the depot.
+
+echo "Running Pkg.gc()"
 julia --color=yes -e 'using Pkg; using Dates; Pkg.gc(; collect_delay=Day(1), force=true, verbose=true)'
 
-### Step 3: If the cache is still greater than the hard limit, clear the entire cache.
 
-CACHE_SIZE=$(du --block-size 1 --summarize $CACHE_DIR | cut -f 1)
-CACHE_HARD_LIMIT=21474836480 # 21474836480 bytes = 20 GiB
-if [[ $CACHE_SIZE -gt $CACHE_HARD_LIMIT]]; then
-    echo "The cache size is $CACHE_SIZE bytes"
-    echo "This is greater than the hard limit ($CACHE_HARD_LIMIT bytes), so we will clear the entire cache"
-    rm -rf $CACHE_DIR
-    mkdir -p $CACHE_DIR
+### Step 3: If the depot is still greater than the hard limit, remove it altogether.
+
+if [[ "${BUILDKITE_PLUGIN_JULIA_ISOLATED_DEPOT:-true}" == "true" ]]; then
+    DEPOT_SIZE=$(du --summarize --bytes "${JULIA_DEPOT_PATH}" | cut -f 1)
+    DEPOT_HARD_LIMIT=21474836480 # 21474836480 bytes = 20 GiB
+    if [[ ${DEPOT_SIZE} -gt ${DEPOT_HARD_LIMIT} ]]; then
+        echo "The depot size is ${DEPOT_SIZE} bytes"
+        echo "This is greater than the hard limit ($DEPOT_HARD_LIMIT bytes), so we will clear the entire cache"
+        rm -rf "${JULIA_DEPOT_PATH}"
+        mkdir -p "${JULIA_DEPOT_PATH}"
+    fi
 fi

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+shopt -s extglob
+
+CACHE_DIR=${BUILDKITE_PLUGIN_JULIA_CACHE_DIR:-${HOME}/.cache/julia-buildkite-plugin}
+
+### Step 1: Remove any code coverage files in the `julia_installs directory.
+### Once JuliaLang/julia#26573 has been fixed, this should no longer be necessary.
+
+find $(CACHE_DIR)/julia_installs -name "*.jl.*.cov" -type f -delete
+
+### Step 2: Run `Pkg.gc` to try to reduce the size of the cache.
+
+echo "Running Pkg.gc"
+julia --color=yes -e 'using Pkg; using Dates; Pkg.gc(; collect_delay=Day(1), force=true, verbose=true)'
+
+### Step 3: If the cache is still greater than the hard limit, clear the entire cache.
+
+CACHE_SIZE=$(du --block-size 1 --summarize $CACHE_DIR | cut -f 1)
+CACHE_HARD_LIMIT=21474836480 # 21474836480 bytes = 20 GiB
+if [[ $CACHE_SIZE -gt $CACHE_HARD_LIMIT]]; then
+    echo "The cache size is $CACHE_SIZE bytes"
+    echo "This is greater than the hard limit ($CACHE_HARD_LIMIT bytes), so we will clear the entire cache"
+    rm -rf $CACHE_DIR
+    mkdir -p $CACHE_DIR
+fi


### PR DESCRIPTION
See #17 for context.

This pull request creates a `pre-exit` hook with the following steps:
1. Delete all code coverage files in the `julia_installs` directory.
2. Run `Pkg.gc(Day(1))`.
3. At this point, if the cache size is greater than the "hard limit", we delete the entire cache.

I've hard-coded the hard limit as 20 GiB, but we could also choose to make it user-configurable. The hard limit is intentionally very high, because in ideal usage we will never actually hit the hard limit (working under the assumption that the `Pkg.gc` should do a good job of removing stale artifacts and packages).