### PR TITLE
`pre-exit` cache cleanup: restore some of the kwargs to `Pkg.gc`

### DIFF
--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -23,7 +23,7 @@ fi
 ### Step 2: Run `Pkg.gc` to try to reduce the size of the depot.
 
 echo "Running Pkg.gc()"
-julia --color=yes -e 'using Pkg; using Dates; Pkg.gc()'
+julia --color=yes -e 'using Pkg; using Dates; Pkg.gc(; collect_delay=Day(7), verbose=true)'
 
 
 ### Step 3: If the depot is still greater than the hard limit, remove it altogether.

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -23,7 +23,7 @@ fi
 ### Step 2: Run `Pkg.gc` to try to reduce the size of the depot.
 
 echo "Running Pkg.gc()"
-julia --color=yes -e 'using Pkg; using Dates; Pkg.gc(; collect_delay=Day(7), verbose=true)'
+julia --color=yes -e 'using Pkg; using Dates; Pkg.gc(; collect_delay=Day(30), verbose=true)'
 
 
 ### Step 3: If the depot is still greater than the hard limit, remove it altogether.


### PR DESCRIPTION
See also: https://github.com/JuliaCI/julia-buildkite-plugin/commit/471233855e3c15a0239d7f6e30f00a236b6cdb0f

If you look at the latest log (https://buildkite.com/julialang/cuda-dot-jl/builds/1917#00b13bb1-d8ec-48ba-87ed-82552fa1b226), `Pkg.gc` didn't actually delete anything.

The `verbose` flag will list out the active manifests, so we can try to figure out why nothing got deleted. It's possible that we might need to delete some of the active manifests before running `Pkg.gc`.