### PR TITLE
`pre-exit` hook: always print the depot size, for debugging purposes

### DIFF
--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -31,8 +31,8 @@ julia --color=yes -e 'using Pkg; using Dates; Pkg.gc()'
 if [[ "${BUILDKITE_PLUGIN_JULIA_ISOLATED_DEPOT:-true}" == "true" ]]; then
     DEPOT_SIZE=$(du --summarize --bytes "${JULIA_DEPOT_PATH}" | cut -f 1)
     DEPOT_HARD_LIMIT=21474836480 # 21474836480 bytes = 20 GiB
+    echo "The depot size is ${DEPOT_SIZE} bytes"
     if [[ ${DEPOT_SIZE} -gt ${DEPOT_HARD_LIMIT} ]]; then
-        echo "The depot size is ${DEPOT_SIZE} bytes"
         echo "This is greater than the hard limit ($DEPOT_HARD_LIMIT bytes), so we will clear the entire cache"
         rm -rf "${JULIA_DEPOT_PATH}"
         mkdir -p "${JULIA_DEPOT_PATH}"

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -29,11 +29,12 @@ julia --color=yes -e 'using Pkg; using Dates; Pkg.gc()'
 ### Step 3: If the depot is still greater than the hard limit, remove it altogether.
 
 if [[ "${BUILDKITE_PLUGIN_JULIA_ISOLATED_DEPOT:-true}" == "true" ]]; then
+    DEPOT_SIZE_HUMAN=$(du --human-readable --summarize "${JULIA_DEPOT_PATH}")
     DEPOT_SIZE=$(du --summarize --bytes "${JULIA_DEPOT_PATH}" | cut -f 1)
     DEPOT_HARD_LIMIT=21474836480 # 21474836480 bytes = 20 GiB
-    echo "The depot size is ${DEPOT_SIZE} bytes"
+    echo "The depot size is: ${DEPOT_SIZE_HUMAN}"
     if [[ ${DEPOT_SIZE} -gt ${DEPOT_HARD_LIMIT} ]]; then
-        echo "This is greater than the hard limit ($DEPOT_HARD_LIMIT bytes), so we will clear the entire cache"
+        echo "This is greater than the hard limit (${DEPOT_SIZE} > ${DEPOT_HARD_LIMIT} bytes), so we will clear the entire depot"
         rm -rf "${JULIA_DEPOT_PATH}"
         mkdir -p "${JULIA_DEPOT_PATH}"
     fi


### PR DESCRIPTION
It might be helpful, at least in the short-term, to always print the depot size, so we can try to get a sense of which depots are growing over time, and which depots are staying flat.