### PR TITLE
Parameterize `collect_delay`

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -19,7 +19,7 @@ JULIA_VERSION="${BUILDKITE_PLUGIN_JULIA_VERSION}"
 if [[ "${BUILDKITE_PLUGIN_JULIA_ISOLATED_DEPOT:-true}" == "true" ]]; then
     # Export `JULIA_DEPOT_PATH` so that future julia invocations use this depot
     export JULIA_DEPOT_PATH="${CACHE_DIR}/depots/${BUILDKITE_PIPELINE_ID}"
-    PERSIST_DEPOT_DIRS="$(echo ${BUILDKITE_PLUGIN_JULIA_PERSIST_DEPOT_DIRS:-registries,packages,artifacts,compiled,datadeps} | tr ',' ' ' )"
+    PERSIST_DEPOT_DIRS="$(echo ${BUILDKITE_PLUGIN_JULIA_PERSIST_DEPOT_DIRS:-registries,packages,artifacts,compiled,datadeps,logs} | tr ',' ' ' )"
 
     # Helper function to join a list of arguments by a particular character
     function join_by { local IFS="$1"; shift; echo "$*"; }

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -31,12 +31,15 @@ echo "Running Pkg.gc()"
 GC_CMD="""
 using Pkg, Dates
 
+# Allow the user to customize whether items are GC'ed immediately or not
+collect_delay = parse(Int64, get(ENV, \"BUILDKITE_PLUGIN_JULIA_CLEANUP_COLLECT_DELAY\", \"0\"))
+
 if VERSION >= v\"1.6-\"
     # If we're on v1.6+, we can use verbose, which is nice
-    Pkg.gc(collect_delay=Second(0), verbose=true)
+    Pkg.gc(collect_delay=Second(collect_delay), verbose=true)
 elseif VERSION >= v\"1.3-\"
     # If we're on v1.3+, we must set the collect_delay low
-    Pkg.gc(collect_delay=Second(0))
+    Pkg.gc(collect_delay=Second(collect_delay))
 else
     # Otherwise, on truly old versions, the only thing we can do is call gc()
     Pkg.gc()

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -32,7 +32,8 @@ GC_CMD="""
 using Pkg, Dates
 
 # Allow the user to customize whether items are GC'ed immediately or not
-collect_delay = parse(Int64, get(ENV, \"BUILDKITE_PLUGIN_JULIA_CLEANUP_COLLECT_DELAY\", \"0\"))
+# Defaults to deleting things after a week of inactivity
+collect_delay = parse(Int64, get(ENV, \"BUILDKITE_PLUGIN_JULIA_CLEANUP_COLLECT_DELAY\", \"604800\"))
 
 if VERSION >= v\"1.6-\"
     # If we're on v1.6+, we can use verbose, which is nice

--- a/plugin.yml
+++ b/plugin.yml
@@ -12,4 +12,6 @@ configuration:
       type: string
     depot_hard_size_limit:
       type: string
+    cleanup_collect_delay:
+      type: string
   additionalProperties: false


### PR DESCRIPTION
It is occasionally helpful to slow down the GC train, as we may be
running jobs again and again, so let the user specify a GC interval in
seconds.