### PR TITLE
Use `python` if `python3` doesn't exist

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -50,6 +50,21 @@ else
     exit 1
 fi
 
+# Look around to find `python3`; if it doesn't exist, complain
+if [[ ! -v BUILDKITE_PLUGIN_JULIA_PYTHON ]]; then
+    if [[ -n "$(which python3 2>/dev/null)" ]]; then
+        PYTHON="$(which python3)"
+    elif [[ -n "$(which python 2>/dev/null)" ]] && [[ "$(python --version)" == "Python 3"* ]]; then
+        PYTHON="$(which python)"
+    fi
+else
+    PYTHON="$(which "${BUILDKITE_PLUGIN_JULIA_PYTHON}")"
+fi
+
+if [[ ! -x "${PYTHON:-}" ]]; then
+    buildkite-agent annotate --style warning "No python 3 available!"
+    exit 1
+fi
 
 # Next, let's download Julia by calculating the URL we'll download from,
 # then using `curl`/`wget`'s timestamping features to re-download if the
@@ -125,7 +140,7 @@ elif [[ "$JULIA_VERSION" =~ ^(.+)-nightly$ ]]; then # for example, `version: '1.
 else
     bucket="julialang-s3"
     if [[ $JULIA_VERSION =~ ^-?[0-9]+$ ]]; then     # for example, `version: '1'` or `version: '234'`
-        release="$(python3 $(dirname $BASH_SOURCE)/expand-major-only.py "${JULIA_VERSION}")"
+        release="$("${PYTHON}" $(dirname $BASH_SOURCE)/expand-major-only.py "${JULIA_VERSION}")"
     else
         release="${JULIA_VERSION}"                  # for example, `version: '123.456'`
     fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -14,4 +14,6 @@ configuration:
       type: string
     cleanup_collect_delay:
       type: string
+    python:
+      type: string
   additionalProperties: false


### PR DESCRIPTION
If `python` is actually python 3.X, go ahead and use it.  This is necessary because my windows buildkite agent that I'm setting up only has `python.exe`, not `python3.exe`.