### PR TITLE
Allow `arch` YAML parameter to override default arch

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -52,6 +52,30 @@ steps:
     commands: |
       [[ "$$(julia --version)" == "julia version 1."* ]]
 
+  - label: ":julia: :macos: macOS x86_64 installation test"
+    agents:
+      queue: "juliaecosystem"
+      os: "macos"
+      arch: "x86_64"
+    plugins:
+      # Test asking for a `nightly` build
+      - "./.buildkite/plugins/julia":
+          version: nightly
+    commands: |
+      [[ "$$(julia --version)" == "julia version 1."* ]]
+
+  - label: ":julia: :macos: macOS x86_64 nightly installation test"
+    agents:
+      queue: "juliaecosystem"
+      os: "macos"
+      arch: "x86_64"
+    plugins:
+      # Test asking for a `nightly` build
+      - "./.buildkite/plugins/julia":
+          version: nightly
+    commands: |
+      [[ "$$(julia --version)" == "julia version 1."* ]]
+
   - label: ":julia: :macos: macOS aarch64 installation test"
     agents:
       queue: "juliaecosystem"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,20 +5,39 @@ steps:
       os: "linux"
       arch: "x86_64"
     plugins:
-      # Install version 1.6 _and_ general `1` build
+      # Install version 1.6 specifically
       - "./.buildkite/plugins/julia":
           version: "1.6"
-      # Test asking for a general `1` build
+    commands: |
+      # Test that we pick up version 1.6
+      [[ "$$(julia --version)" == "julia version 1.6"* ]]
+      [[ "$$(julia -E 'Sys.ARCH')" == ":x86_64" ]]
+
+  - label: ":julia: :linux: Linux i686 installation test"
+    agents:
+      queue: "juliaecosystem"
+      os: "linux"
+      arch: "x86_64"
+    plugins:
+      # Install Julia v1 so we can use Sandbox
+      - JuliaCI/julia:
+          version: "1"
+      # Use Sandbox to run inside of a 32-bit compatible rootfs
+      - staticfloat/sandbox#v1:
+          rootfs_url: "https://github.com/JuliaCI/rootfs-images/releases/download/v5.4/tester_linux.i686.tar.gz"
+          rootfs_treehash: "5791b58219ad5899a44173a922070df8ce90d5c3"
+      # Smoosh python3 into our rootfs
+      - improbable-eng/metahook:
+          pre-command:
+            apt update -y && apt install -y python3
+      # Override the "arch" parameter to install an i686 version inside of the sandbox
       - "./.buildkite/plugins/julia":
-          version: 1
+          version: "1"
+          arch: "i686"
     commands: |
       # Test that we pick up the latest version
       [[ "$$(julia --version)" == "julia version 1."* ]]
-      [[ "$$(julia --version)" != "julia version 1.6"* ]]
-
-      # Ensure that there's another Julia that was installed
-      rm $$(which julia)
-      [[ "$$(julia --version)" == "julia version 1.6"* ]]
+      [[ "$$(julia -E 'Sys.ARCH')" == ":i686" ]]
 
 
   - label: ":julia: :macos: macOS x86_64 installation test"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -24,8 +24,8 @@ steps:
           version: "1"
       # Use Sandbox to run inside of a 32-bit compatible rootfs
       - staticfloat/sandbox#v1:
-          rootfs_url: "https://github.com/JuliaCI/rootfs-images/releases/download/v5.4/tester_linux.i686.tar.gz"
-          rootfs_treehash: "5791b58219ad5899a44173a922070df8ce90d5c3"
+          rootfs_url: "https://github.com/JuliaCI/rootfs-images/releases/download/v5.5/agent_linux.i686.tar.gz"
+          rootfs_treehash: "9335532ac5eb036ebbb0d5b7fa1df0968f8f0f2d"
       # Smoosh python3 into our rootfs
       - improbable-eng/metahook:
           pre-command:

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -137,10 +137,12 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
       "x86_64")
         larch="x64"
         rosarch="mac64"
+        nightly_rosarch="mac64"
         ;;
       "arm64" | "aarch64")
         larch="aarch64"
         rosarch="macaarch64"
+        nightly_rosarch="macaarch64"
         ;;
       *)
         buildkite-agent annotate --style error "Unhandled OS $OSTYPE/arch $ARCH combo"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -82,22 +82,29 @@ if [[ ! -x "${PYTHON:-}" ]]; then
     exit 1
 fi
 
+# We allow the user to override the architecture we download
+ARCH="${BUILDKITE_PLUGIN_JULIA_ARCH:-$(uname -m)}"
+
 # Next, let's download Julia by calculating the URL we'll download from,
 # then using `curl`/`wget`'s timestamping features to re-download if the
 # source URL has updated its contents; if we end up downloading something
 # we'll notice and re-extract by comparing timestamps of the file before
 # and after download.
-echo "--- :julia: Downloading Julia $JULIA_VERSION"
+echo "--- :julia: Downloading Julia ${JULIA_VERSION} for arch ${ARCH}"
 
 # Calculate the download URL
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     os="linux"
-    machine=$(uname -m)
-    case "$machine" in
+    case "$ARCH" in
       "x86_64")
         larch="x64"
         rosarch="linux-x86_64"
         nightly_rosarch="linux64"
+        ;;
+      "i686")
+        larch="x86"
+        rosarch="linux-i686"
+        nightly_rosarch="linux32"
         ;;
       "aarch64")
         larch="aarch64"
@@ -105,55 +112,57 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
         nightly_rosarch="linuxaarch64"
         ;;
       *)
-        buildkite-agent annotate --style error "Unhandled OS $OSTYPE/machine $machine combo"
+        buildkite-agent annotate --style error "Unhandled OS $OSTYPE/arch $ARCH combo"
         exit 1
         ;;
     esac
     ext="tar.gz"
 elif [[ "$OSTYPE" == "linux-musl"* ]]; then
     os="musl"
-    machine=$(uname -m)
-    case "$machine" in
+    case "$ARCH" in
       "x86_64")
         larch="x64"
         rosarch="musl-x86_64"
         nightly_rosarch="musl64"
         ;;
       *)
-        buildkite-agent annotate --style error "Unhandled OS $OSTYPE/machine $machine combo"
+        buildkite-agent annotate --style error "Unhandled OS $OSTYPE/arch $ARCH combo"
         exit 1
         ;;
     esac
     ext="tar.gz"
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     os="mac"
-    machine=$(uname -m)
-    case "$machine" in
+    case "$ARCH" in
       "x86_64")
         larch="x64"
         rosarch="mac64"
         ;;
-      "arm64")
+      "arm64" | "aarch64")
         larch="aarch64"
         rosarch="macaarch64"
         ;;
       *)
-        buildkite-agent annotate --style error "Unhandled OS $OSTYPE/machine $machine combo"
+        buildkite-agent annotate --style error "Unhandled OS $OSTYPE/arch $ARCH combo"
         exit 1
         ;;
     esac
     ext="tar.gz"
 elif [[ "$OSTYPE" == "msys" ]]; then
     os="winnt"
-    machine=$(uname -m)
-    case "$machine" in
+    case "$ARCH" in
       "x86_64")
         larch="x64"
         rosarch="win64"
         nightly_rosarch="win64"
         ;;
+      "i686")
+        larch="x86"
+        rosarch="win32"
+        nightly_rosarch="win32"
+        ;;
       *)
-        buildkite-agent annotate --style error "Unhandled OS $OSTYPE/machine $machine combo"
+        buildkite-agent annotate --style error "Unhandled OS $OSTYPE/arch $ARCH combo"
         exit 1
         ;;
     esac

--- a/plugin.yml
+++ b/plugin.yml
@@ -6,6 +6,8 @@ configuration:
   properties:
     version:
       type: string
+    arch:
+      type: string
     isolated_depot:
       type: boolean
     persist_depot_dirs:


### PR DESCRIPTION
This allows us to download an `i686` version of Julia on `x86_64`
hardware, for instance.