### PR TITLE
Don't hard-code path to bash.

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 shopt -s extglob
 

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 shopt -s extglob
 


### PR DESCRIPTION
Some of the features used here aren't compatible with macOS' system bash (v3.something), so we want to be able to use a more recent version.