### PR TITLE
Support fully specified Julia versions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,6 +21,22 @@ steps:
       [[ "$$(julia --version)" == "julia version 1.6"* ]]
       [[ "$$(julia -E 'Sys.ARCH')" == ":x86_64" ]]
 
+  - label: ":julia: :linux: Linux x86_64 specific version installation test"
+    agents:
+      queue: "juliaecosystem"
+      os: "linux"
+      arch: "x86_64"
+    plugins:
+      - improbable-eng/metahook:
+          <<: *self_test_setup
+      # Install version 1.6.0 specifically, which is _not_ the most recent LTS
+      # release to prevent testing downloading the 'latest' version
+      - "./.buildkite/plugins/julia":
+          version: "1.6.0"
+    commands: |
+      # Test that we pick up version 1.6.0
+      [[ "$$(julia --version)" == "julia version 1.6.0" ]]
+
   - label: ":julia: :linux: Linux i686 installation test"
     agents:
       queue: "juliaecosystem"
@@ -74,6 +90,22 @@ steps:
     commands: |
       [[ "$$(julia --version)" == "julia version 1."* ]]
 
+  - label: ":julia: :macos: macOS x86_64 specific version installation test"
+    agents:
+      queue: "juliaecosystem"
+      os: "macos"
+      arch: "x86_64"
+    plugins:
+      - improbable-eng/metahook:
+          <<: *self_test_setup
+      # Install version 1.6.1 specifically, which is _not_ the most recent LTS
+      # release to prevent testing downloading the 'latest' version
+      - "./.buildkite/plugins/julia":
+          version: "1.6.1"
+    commands: |
+      # Test that we pick up version 1.6.1
+      [[ "$$(julia --version)" == "julia version 1.6.1" ]]
+
   - label: ":julia: :macos: macOS x86_64 nightly installation test"
     agents:
       queue: "juliaecosystem"
@@ -115,6 +147,22 @@ steps:
           version: 1
     commands: |
       [[ "$$(julia --version)" == "julia version 1."* ]]
+
+  - label: ":julia: :windows: Windows x86_64 specific version installation test"
+    agents:
+      queue: "juliaecosystem"
+      os: "windows"
+      arch: "x86_64"
+    plugins:
+      - improbable-eng/metahook:
+          <<: *self_test_setup
+      # Install version 1.6.2 specifically, which is _not_ the most recent LTS
+      # release to prevent testing downloading the 'latest' version
+      - "./.buildkite/plugins/julia":
+          version: "1.6.2"
+    commands: |
+      # Test that we pick up version 1.6.2
+      [[ "$$(julia --version)" == "julia version 1.6.2" ]]
 
   - label: ":julia: :windows: Windows i686 installation test"
     agents:

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -189,13 +189,22 @@ elif [[ "$JULIA_VERSION" =~ ^(.+)-nightly$ ]]; then # for example, `version: '1.
     path="$path/$release/julia-latest-$nightly_rosarch"
 else
     bucket="julialang-s3"
+    # Minor version URLs contain `-latest` in their URLs
+    postfix="-latest"
     if [[ $JULIA_VERSION =~ ^-?[0-9]+$ ]]; then     # for example, `version: '1'` or `version: '234'`
         release="$("${PYTHON}" $(dirname $BASH_SOURCE)/expand-major-only.py "${JULIA_VERSION}")"
-    else
+    elif [[ $JULIA_VERSION =~ ^-?[0-9]+\.[0-9]+$ ]]; then
         release="${JULIA_VERSION}"                  # for example, `version: '123.456'`
+    elif [[ $JULIA_VERSION =~ ^-?[0-9]+(\.[0-9]+){2}$ ]]; then
+        release="${JULIA_VERSION}"                  # for example, `version: '1.2.3'`
+        # Exact versions do _not_ contain `-latest` in their URL
+        postfix=""
+    else
+        buildkite-agent annotate --style error "Unsupported version $JULIA_VERSION"
+        exit 1
     fi
-    # TODO: support for a fully-specified version, e.g. 1.5.3
-    path="$path/$release/julia-$release-latest-$rosarch"
+    short_release="$(cut -d '.' -f 1,2 <<< "$release")"
+    path="$path/$short_release/julia-$release$postfix-$rosarch"
 fi
 url="https://$bucket.julialang.org/$path.$ext"
 


### PR DESCRIPTION
Handling fully specified versions requires a slightly different approach, as they require different URLs than used when obtaining the most recent release in a specific minor release (which the most recent version within a major release expands to as well).

Making the `-latest` postfix optional, explicitly handling all three variants of `<major>.<minor>.<patch>` versions and dynamically determining the `<major>.<minor>` version enables this.

This also reports an error in Buildkite's UI if none of the three cases, i.e. `<major>`, `<major>.<minor>` or `<major>.<minor>.<patch>`, is matched.