### PR TITLE
Use tarballs on windows

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -186,7 +186,7 @@ elif [[ "$OSTYPE" == "msys" ]]; then
         exit 1
         ;;
     esac
-    ext="zip"
+    ext="tar.gz"
 else
     buildkite-agent annotate --style error "Unhandled OS $OSTYPE"
     exit 1


### PR DESCRIPTION
I have been running into issues using `.zip` files on windows when downloading nightly builds [1], I want to see if this helps anything.

[1] https://buildkite.com/julialang/libblastrampoline/builds/42#0184bfe0-fc70-4065-8e30-a3030bdd3ea0