### PR TITLE
Use `du -k` to get size of depot in kilobytes

### DIFF
--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -64,7 +64,7 @@ if [[ "${BUILDKITE_PLUGIN_JULIA_ISOLATED_DEPOT:-true}" == "true" ]]; then
     DEPOT_SIZE_HUMAN=$(du "${DU_APPARENT_SIZE_FLAG}" -h -s "${JULIA_DEPOT_PATH}" | cut -f 1)
     # `-k` gives consistently the number of kilobytes on both macOS and Linux, without it
     # BSD `du` would give the number of multiples of 512 bytes.
-    DEPOT_SIZE=$(($(du "${DU_APPARENT_SIZE_FLAG}" -k -s -B 1 "${JULIA_DEPOT_PATH}" | cut -f 1) * 1024))
+    DEPOT_SIZE=$(($(du "${DU_APPARENT_SIZE_FLAG}" -k -s "${JULIA_DEPOT_PATH}" | cut -f 1) * 1024))
     DEPOT_HARD_LIMIT="${BUILDKITE_PLUGIN_JULIA_DEPOT_HARD_SIZE_LIMIT:-21474836480}" # 21474836480 bytes = 20 GiB
     echo "The depot size is: ${DEPOT_SIZE_HUMAN}"
     if [[ ${DEPOT_SIZE} -gt ${DEPOT_HARD_LIMIT} ]]; then

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -61,8 +61,10 @@ fi
 
 ### Step 3: If the depot is still greater than the hard limit, remove it altogether.
 if [[ "${BUILDKITE_PLUGIN_JULIA_ISOLATED_DEPOT:-true}" == "true" ]]; then
-    DEPOT_SIZE_HUMAN=$(du -h -s "${JULIA_DEPOT_PATH}" | cut -f 1)
-    DEPOT_SIZE=$(du ${DU_APPARENT_SIZE_FLAG} -s -B 1 "${JULIA_DEPOT_PATH}" | cut -f 1)
+    DEPOT_SIZE_HUMAN=$(du "${DU_APPARENT_SIZE_FLAG}" -h -s "${JULIA_DEPOT_PATH}" | cut -f 1)
+    # `-k` gives consistently the number of kilobytes on both macOS and Linux, without it
+    # BSD `du` would give the number of multiples of 512 bytes.
+    DEPOT_SIZE=$(($(du "${DU_APPARENT_SIZE_FLAG}" -k -s -B 1 "${JULIA_DEPOT_PATH}" | cut -f 1) * 1024))
     DEPOT_HARD_LIMIT="${BUILDKITE_PLUGIN_JULIA_DEPOT_HARD_SIZE_LIMIT:-21474836480}" # 21474836480 bytes = 20 GiB
     echo "The depot size is: ${DEPOT_SIZE_HUMAN}"
     if [[ ${DEPOT_SIZE} -gt ${DEPOT_HARD_LIMIT} ]]; then

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -53,18 +53,12 @@ end
 """
 julia --color=yes -e "${GC_CMD}" || true
 
-if [[ "${OSTYPE}" == "darwin"* ]] || [[ "${OSTYPE}" == "freebsd"* ]]; then
-    DU_APPARENT_SIZE_FLAG="-A"
-else
-    DU_APPARENT_SIZE_FLAG="--apparent-size"
-fi
-
 ### Step 3: If the depot is still greater than the hard limit, remove it altogether.
 if [[ "${BUILDKITE_PLUGIN_JULIA_ISOLATED_DEPOT:-true}" == "true" ]]; then
-    DEPOT_SIZE_HUMAN=$(du "${DU_APPARENT_SIZE_FLAG}" -h -s "${JULIA_DEPOT_PATH}" | cut -f 1)
+    DEPOT_SIZE_HUMAN=$(du -h -s "${JULIA_DEPOT_PATH}" | cut -f 1)
     # `-k` gives consistently the number of kilobytes on both macOS and Linux, without it
     # BSD `du` would give the number of multiples of 512 bytes.
-    DEPOT_SIZE=$(($(du "${DU_APPARENT_SIZE_FLAG}" -k -s "${JULIA_DEPOT_PATH}" | cut -f 1) * 1024))
+    DEPOT_SIZE=$(($(du -k -s "${JULIA_DEPOT_PATH}" | cut -f 1) * 1024))
     DEPOT_HARD_LIMIT="${BUILDKITE_PLUGIN_JULIA_DEPOT_HARD_SIZE_LIMIT:-21474836480}" # 21474836480 bytes = 20 GiB
     echo "The depot size is: ${DEPOT_SIZE_HUMAN}"
     if [[ ${DEPOT_SIZE} -gt ${DEPOT_HARD_LIMIT} ]]; then


### PR DESCRIPTION
This is more consistent than the output of `du` without this option across different operating systems.

Should hopefully fix the inconsistency in #43.  CC: @benlorenz.