### PR TITLE
Add `url` plugin option to support overriding the desired download URL

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -44,3 +44,6 @@ steps:
       AGENT_OS="windows"
       upload_pipelines x86_64 "1 nightly"
       upload_pipelines i686   "1 nightly"
+
+      # Launch a custom URL tests
+      buildkite-agent pipeline upload ".buildkite/run_tests_custom_url.yml"

--- a/.buildkite/run_tests.yml
+++ b/.buildkite/run_tests.yml
@@ -14,6 +14,7 @@ steps:
           <<: *self_test_setup
       - "./.buildkite/plugins/julia":
           version: "${JULIA_VERSION?}"
+          debug_plugin: "true"
     commands: |
       # If we asked for a nightly version, just check that we got a `1.X`:
       CHECK_VERSION="${JULIA_VERSION?}"

--- a/.buildkite/run_tests_custom_url.yml
+++ b/.buildkite/run_tests_custom_url.yml
@@ -15,6 +15,7 @@ steps:
       - "./.buildkite/plugins/julia":
           # version is ignored when `url` is provided
           version: "https://julialang-s3.julialang.org/bin/linux/x64/1.9/julia-1.9.0-rc1-linux-x86_64.tar.gz"
+          debug_plugin: "true"
     commands: |
       # If we asked for a nightly version, just check that we got a `1.X`:
       [[ "$$(julia --version)" == "julia version 1.9.0-rc1" ]]

--- a/.buildkite/run_tests_custom_url.yml
+++ b/.buildkite/run_tests_custom_url.yml
@@ -1,0 +1,23 @@
+self_test_setup: &self_test_setup
+  post-checkout: |
+    mkdir -p .buildkite/plugins/julia
+    cp -Ra hooks plugin.yml README.md .buildkite/plugins/julia/
+
+steps:
+  - label: ":julia: linux x86_64 custom URL"
+    agents:
+      queue: "juliaecosystem"
+      os: "linux"
+      arch: "x86_64"
+    plugins:
+      - staticfloat/metahook#sf/windows_backslashes:
+          <<: *self_test_setup
+      - "./.buildkite/plugins/julia":
+          # version is ignored when `url` is provided
+          version: "https://julialang-s3.julialang.org/bin/linux/x64/1.9/julia-1.9.0-rc1-linux-x86_64.tar.gz"
+    commands: |
+      # If we asked for a nightly version, just check that we got a `1.X`:
+      [[ "$$(julia --version)" == "julia version 1.9.0-rc1" ]]
+
+      # Always check we got the right architecture
+      [[ "$$(julia -E 'Sys.ARCH')" == ":x86_64" ]]

--- a/.buildkite/run_tests_linux32.yml
+++ b/.buildkite/run_tests_linux32.yml
@@ -21,6 +21,7 @@ steps:
       - "./.buildkite/plugins/julia":
           version: "${JULIA_VERSION?}"
           arch: "i686"
+          debug_plugin: "true"
     commands: |
       # If we asked for a nightly version, just check that we got a `1.X`:
       CHECK_VERSION="${JULIA_VERSION?}"

--- a/.buildkite/run_tests_windows32.yml
+++ b/.buildkite/run_tests_windows32.yml
@@ -15,6 +15,7 @@ steps:
       - "./.buildkite/plugins/julia":
           version: "${JULIA_VERSION?}"
           arch: "i686"
+          debug_plugin: "true"
     commands: |
       # If we asked for a nightly version, just check that we got a `1.X`:
       CHECK_VERSION="${JULIA_VERSION?}"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -8,6 +8,7 @@ shopt -s extglob
 ## If we're running in debug mode, be REALLY VERBOSE:
 if [[ "${BUILDKITE_PLUGIN_JULIA_DEBUG_PLUGIN:-false}" == "true" ]]; then
     set -x
+    PS4="> "
 fi
 
 # Where Julia will be downloaded/extracted to, and where we'll store our depots and whatnot

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -17,6 +17,12 @@ CACHE_DIR=${BUILDKITE_PLUGIN_JULIA_CACHE_DIR:-${HOME}/.cache/julia-buildkite-plu
 # The version of Julia we're downloading
 JULIA_VERSION="${BUILDKITE_PLUGIN_JULIA_VERSION}"
 
+# Did we get a julia version that's actually a URL?
+if [[ "${JULIA_VERSION}" == "https://"* ]]; then
+    CUSTOM_URL="${JULIA_VERSION#https://*}"
+    JULIA_VERSION="<custom url>"
+fi
+
 # If the user has asked for an isolated depot, we will create one inside of `CACHE_DIR`
 # that is specific to the current pipeline; use `PERSIST_DEPOT_DIRS` to keep some directories
 # around between invocations; by default we persist content-addressed directories such as
@@ -92,7 +98,7 @@ ARCH="${BUILDKITE_PLUGIN_JULIA_ARCH:-$(uname -m)}"
 # and after download.
 echo "--- :julia: Downloading Julia ${JULIA_VERSION} for arch ${ARCH}"
 
-# Calculate the download URL
+# Calculate the download URL, unless the user is asking for a custom URL:
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     os="linux"
     nightly_os="linux"
@@ -193,15 +199,22 @@ else
 fi
 
 path="bin/$os/$larch"
-if [[ "$JULIA_VERSION" == "nightly" ]]; then        # `version: 'nightly'`
-    bucket="julialangnightlies-s3"
+if [[ -n "${CUSTOM_URL:-}" ]]; then
+    echo "Overriding version selection, using custom URL '${CUSTOM_URL}'"
+
+    # Parse `CUSTOM_URL` into `bucket_host` and `path` pieces, trimming `${ext}` off the end.
+    bucket_host="${CUSTOM_URL%%/*}"
+    path="${CUSTOM_URL#*/}"
+    path="${path%%.${ext}}"
+elif [[ "$JULIA_VERSION" == "nightly" ]]; then        # `version: 'nightly'`
+    bucket_host="julialangnightlies-s3.julialang.org"
     path="bin/$nightly_os/$nightly_larch/julia-latest-$nightly_rosarch"
 elif [[ "$JULIA_VERSION" =~ ^(.+)-nightly$ ]]; then # for example, `version: '1.6-nightly'`
-    bucket="julialangnightlies-s3"
+    bucket_host="julialangnightlies-s3.julialang.org"
     release="${BASH_REMATCH[1]}"
     path="bin/$nightly_os/$nightly_larch/$release/julia-latest-$nightly_rosarch"
 else
-    bucket="julialang-s3"
+    bucket_host="julialang-s3.julialang.org"
     # Minor version URLs contain `-latest` in their URLs
     postfix="-latest"
     if [[ $JULIA_VERSION =~ ^-?[0-9]+$ ]]; then     # for example, `version: '1'` or `version: '234'`
@@ -219,7 +232,7 @@ else
     short_release="$(cut -d '.' -f 1,2 <<< "$release")"
     path="$path/$short_release/julia-$release$postfix-$rosarch"
 fi
-url="https://$bucket.julialang.org/$path.$ext"
+url="https://$bucket_host/$path.$ext"
 
 # Download Julia to our cache directory.  If the file already exists, this may take
 # only a few hundred milliseconds, as it checks the timestamp of the file on the


### PR DESCRIPTION
This is useful when you want to use this plugin with some kind of internal build of Julia.  While it overrides things like the selected `version` and `arch`, it still has to do a bit of a dance to parse the URL out appropriately, only supports `https`, and may have other limitations.  I'm open to reimplementing this in a better way.