### PR TITLE
Set `$PS4` before `set -x`

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -7,8 +7,8 @@ shopt -s extglob
 
 ## If we're running in debug mode, be REALLY VERBOSE:
 if [[ "${BUILDKITE_PLUGIN_JULIA_DEBUG_PLUGIN:-false}" == "true" ]]; then
-    set -x
     PS4="> "
+    set -x
 fi
 
 # Where Julia will be downloaded/extracted to, and where we'll store our depots and whatnot


### PR DESCRIPTION
This prevents us from getting a single errant `+++` at the beginning of our test output.