### PR TITLE
Keep disk usage in track

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,23 @@ steps:
 
 ### Advanced Options
 
-* `arch`: a string specifying the architecture to download Julia for. Defaults to `uname -m`.
-* `cache_dir`: a string specifying a location for maintaining a cache of Julia installations, depots, etc. Defaults to `${HOME}/.cache/julia-buildkite-plugin`. Persist this directory on your agents to speed up subsequent builds.
-* `cleanup_collect_delay`: a string specifying a period in seconds after which package garbage collection, i.e. [`Pkg.gc`](https://pkgdocs.julialang.org/v1/api/#Pkg.gc), will consider orphaned items for cleanup. Defaults to `604800` seconds, i.e. 1 week.
-* `debug_plugin`: a boolean, which defaults to `false`, severely increasing the verbosity of the plugin for debugging purposes.
-* `python`: a string specifying the path to a Python 3 distribution. The plugin will try to autodetect the location of a Python 3 installation by default.
+* `arch`: a string specifying the architecture to download Julia for. Defaults
+  to `uname -m`.
+* `cache_dir`: a string specifying a location for maintaining a cache of Julia
+  installations, depots, etc. Defaults to
+  `${HOME}/.cache/julia-buildkite-plugin`. Persist this directory on your agents
+  to speed up subsequent builds.
+* `cleanup_collect_delay`: a string specifying a period in seconds after which
+  package garbage collection, i.e.
+  [`Pkg.gc`](https://pkgdocs.julialang.org/v1/api/#Pkg.gc), will consider
+  orphaned items for cleanup. Defaults to `604800` seconds, i.e. 1 week.
+* `pipeline_age_limit`: a string specifying a period in seconds after which the
+  pipeline-specific depot will be considered stale and removed. Defaults to
+  `2592000` seconds, i.e. 30 days.
+* `compilecache_size_limit`: a string specifying the maximum size of the
+  compilecache in bytes. Defaults to `1073741824` bytes, i.e. 1 GiB.
+* `debug_plugin`: a boolean, which defaults to `false`, severely increasing the
+  verbosity of the plugin for debugging purposes.
+* `python`: a string specifying the path to a Python 3 distribution. The plugin
+  will try to autodetect the location of a Python 3 installation by default.
 * `update_registry`: a boolean, which defaults to `true`, indicating whether to update the package registry.

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -44,6 +44,11 @@ if [[ "${BUILDKITE_PLUGIN_JULIA_ISOLATED_DEPOT:-true}" == "true" ]]; then
         rm -rf -- !($(join_by "|" ${PERSIST_DEPOT_DIRS}))
         popd >/dev/null
     fi
+
+    # Mark the depot as in-use by touching it
+    if [[ -d "${JULIA_DEPOT_PATH}" ]]; then
+        touch "${JULIA_DEPOT_PATH}"
+    fi
 else
     if [[ -v BUILDKITE_PLUGIN_JULIA_PERSIST_DEPOT_DIRS ]]; then
         buildkite-agent annotate --style warning "persist_depot_dirs specified with a non-isolated depot; this has no effect."

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -12,7 +12,7 @@ CACHE_DIR=${BUILDKITE_PLUGIN_JULIA_CACHE_DIR:-${HOME}/.cache/julia-buildkite-plu
 echo "--- :broom: Performing clean-up"
 
 
-### Step 1: Remove any code coverage files
+### Step 1: Remove any code coverage files.
 
 echo "Removing coverage files"
 
@@ -25,27 +25,29 @@ if [[ "${BUILDKITE_PLUGIN_JULIA_ISOLATED_DEPOT:-true}" == "true" ]]; then
 fi
 
 
-### Step 2: Run `Pkg.gc` to try to reduce the size of the depot.
+### Step 2: Reduce the size of our depot by running `Pkg.gc`.
 
 # since we remove most manifests at the start of each pipeline (cleaning the depot),
 # there's no way for Pkg to actually track which artifacts are active, so we just invoke
 # `gc()` with `collect_delay` set to zero to cause immediate collection on versions of
 # julia that are new enough to have a generational Pkg GC.
 
+# Allow the user to customize whether items are GC'ed immediately or not
+# Defaults to deleting things after a week of inactivity
+CLEANUP_COLLECT_DELAY="${BUILDKITE_PLUGIN_JULIA_CLEANUP_COLLECT_DELAY:-604800}" # 1 week
+
 GC_CMD="""
 using Pkg, Dates
 
-# Allow the user to customize whether items are GC'ed immediately or not
-# Defaults to deleting things after a week of inactivity
-collect_delay = parse(Int64, get(ENV, \"BUILDKITE_PLUGIN_JULIA_CLEANUP_COLLECT_DELAY\", \"604800\"))
+collect_delay = SecondIparse(Int64, ARGS[1]))
 
 @info(\"Running Pkg.gc()\", collect_delay)
 if VERSION >= v\"1.6-\"
     # If we're on v1.6+, we can use verbose, which is nice
-    Pkg.gc(collect_delay=Second(collect_delay), verbose=true)
+    Pkg.gc(collect_delay=collect_delay, verbose=true)
 elseif VERSION >= v\"1.3-\"
     # If we're on v1.3+, we must set the collect_delay low
-    Pkg.gc(collect_delay=Second(collect_delay))
+    Pkg.gc(collect_delay=collect_delay)
 else
     # Otherwise, on truly old versions, the only thing we can do is call gc()
     Pkg.gc()

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -39,7 +39,7 @@ CLEANUP_COLLECT_DELAY="${BUILDKITE_PLUGIN_JULIA_CLEANUP_COLLECT_DELAY:-604800}" 
 GC_CMD="""
 using Pkg, Dates
 
-collect_delay = SecondIparse(Int64, ARGS[1]))
+collect_delay = Second(parse(Int64, ARGS[1]))
 
 @info(\"Running Pkg.gc()\", collect_delay)
 if VERSION >= v\"1.6-\"
@@ -53,19 +53,58 @@ else
     Pkg.gc()
 end
 """
-julia --color=yes -e "${GC_CMD}" || true
+julia --color=yes -e "${GC_CMD}" "${CLEANUP_COLLECT_DELAY}" || true
 
-### Step 3: If the depot is still greater than the hard limit, remove it altogether.
-if [[ "${BUILDKITE_PLUGIN_JULIA_ISOLATED_DEPOT:-true}" == "true" ]]; then
-    DEPOT_SIZE_HUMAN=$(du -h -s "${JULIA_DEPOT_PATH}" | cut -f 1)
-    # `-k` gives consistently the number of kilobytes on both macOS and Linux, without it
-    # BSD `du` would give the number of multiples of 512 bytes.
-    DEPOT_SIZE=$(($(du -k -s "${JULIA_DEPOT_PATH}" | cut -f 1) * 1024))
-    DEPOT_HARD_LIMIT="${BUILDKITE_PLUGIN_JULIA_DEPOT_HARD_SIZE_LIMIT:-21474836480}" # 21474836480 bytes = 20 GiB
-    echo "The depot size is: ${DEPOT_SIZE_HUMAN}"
-    if [[ ${DEPOT_SIZE} -gt ${DEPOT_HARD_LIMIT} ]]; then
-        echo "This is greater than the hard limit (${DEPOT_SIZE} > ${DEPOT_HARD_LIMIT} bytes), so we will clear the entire depot"
-        rm -rf "${JULIA_DEPOT_PATH}"
-        mkdir -p "${JULIA_DEPOT_PATH}"
+
+### Step 3: Reduce the size of our depot by removing old precompilation files.
+
+# Julia does not track when a precompilation file was last used, so we simply
+# remove files in the `compiled` directory until we are below the hard limit.
+
+COMPILECACHE="${JULIA_DEPOT_PATH}/compiled"
+
+if [[ "${BUILDKITE_PLUGIN_JULIA_ISOLATED_DEPOT:-true}" == "true" ]] && [[ -d "${COMPILECACHE}" ]]; then
+    CACHE_SIZE_HUMAN=$(du -h -s "${COMPILECACHE}" | cut -f 1)
+    # `-k` gives consistently the number of kilobytes on both macOS and Linux,
+    # without it BSD `du` would give the number of multiples of 512 bytes.
+    CACHE_SIZE=$(($(du -k -s "${COMPILECACHE}" | cut -f 1) * 1024))
+    CACHE_LIMIT="${BUILDKITE_PLUGIN_JULIA_COMPILECACHE_SIZE_LIMIT:-1073741824}"
+    echo "The compilation cache size is: ${CACHE_SIZE_HUMAN}"
+
+    if [[ ${CACHE_SIZE} -gt ${CACHE_LIMIT} ]]; then
+        echo "This is greater than the hard limit (${CACHE_SIZE} > ${CACHE_LIMIT} bytes), so we will clear the compilation cache"
+
+        # Remove oldest files until we are below the hard limit
+        # We do this in Julia to avoid platform portability issues.
+        julia --color=yes -e '
+            function main(compilecache, cache_size_str, cache_limit_str)
+                cache_size = parse(Int, cache_size_str)
+                cache_limit = parse(Int, cache_limit_str)
+
+                # Get all files with their modification times
+                files = []
+                for (root, _, files_in_dir) in walkdir(compilecache)
+                    for file in files_in_dir
+                        path = joinpath(root, file)
+                        push!(files, (; path, stat=stat(path)))
+                    end
+                end
+
+                # Sort by modification time (oldest first)
+                sort!(files; by=file->file.stat.mtime)
+
+                # Remove files until we are under the limit
+                for file in files
+                    rm(file.path)
+                    cache_size -= file.stat.size
+                    cache_size <= cache_limit && break
+                end
+            end
+
+            main(ARGS...)
+        ' "${COMPILECACHE}" "${CACHE_SIZE}" "${CACHE_LIMIT}" || true
+
+        # Cleanup empty directories
+        find "${COMPILECACHE}" -type d -empty -delete
     fi
 fi

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -108,3 +108,32 @@ if [[ "${BUILDKITE_PLUGIN_JULIA_ISOLATED_DEPOT:-true}" == "true" ]] && [[ -d "${
         find "${COMPILECACHE}" -type d -empty -delete
     fi
 fi
+
+
+### Step 4: Remove old depots.
+
+# We mark a depot as in-use by `touch`ing it at the start of the pipeline,
+# so we can remove any depots that are older than a certain age.
+
+PIPELINE_AGE_LIMIT="${BUILDKITE_PLUGIN_JULIA_PIPELINE_AGE_LIMIT:-2592000}"
+
+julia --color=yes -e '
+    function main(depots_dir, age_limit_str)
+        age_limit = parse(Int, age_limit_str)
+        current_time = time()
+
+        # Process all depot directories
+        for depot in readdir(depots_dir; join=true)
+            isdir(depot) || continue
+            depot_age = current_time - mtime(depot)
+            if depot_age > age_limit
+                println("Removing old depot: ", depot)
+
+                # Old versions of Julia cannot reliably chmod or rm directories
+                run(ignorestatus(`chmod -R u+w $depot`))
+                run(ignorestatus(`rm -rf $depot`))
+            end
+        end
+    end
+    main(ARGS...)
+' "${CACHE_DIR}"/depots "${PIPELINE_AGE_LIMIT}" || true


### PR DESCRIPTION
Hopefully fixes https://github.com/JuliaCI/julia-buildkite-plugin/issues/17 by:
- removing old `compiled` entries until the cache is 1GiB
- removing old `depots` from pipelines that haven't run in a month

This is in addition to infrastructural changes like using filesystem-level deduplication.