### PR TITLE
Fix distutils.version removed in python 3.12

### DIFF
--- a/hooks/expand-major-only.py
+++ b/hooks/expand-major-only.py
@@ -1,9 +1,28 @@
-import distutils.version
 import json
+import re
 import sys
 import urllib.request
 
-distutils.version.StrictVersion
+class SimpleVersion:
+    """Simple version class using only standard library"""
+    def __init__(self, version_string):
+        self.version_string = version_string
+        # Parse version string like "1.9.3" into components
+        match = re.match(r'^(\d+)\.(\d+)\.(\d+)', version_string)
+        if not match:
+            raise ValueError(f"Invalid version string: {version_string}")
+        self.major = int(match.group(1))
+        self.minor = int(match.group(2))
+        self.micro = int(match.group(3))
+    
+    def __lt__(self, other):
+        return (self.major, self.minor, self.micro) < (other.major, other.minor, other.micro)
+    
+    def __eq__(self, other):
+        return (self.major, self.minor, self.micro) == (other.major, other.minor, other.micro)
+    
+    def __str__(self):
+        return self.version_string
 
 def download_versions_json(url = "https://julialang-s3.julialang.org/bin/versions.json"):
     request = urllib.request.Request(url)
@@ -20,18 +39,18 @@ def get_stable_versions(parsed_json):
             if is_stable:
                 stable_version_strings.append(key)
     stable_version_strings_unique = list(set(stable_version_strings))
-    stable_versions = [distutils.version.StrictVersion(s) for s in stable_version_strings_unique]
+    stable_versions = [SimpleVersion(s) for s in stable_version_strings_unique]
     stable_versions.sort()
     return stable_versions
 
-def get_major(version):
-    return version.version[0]
+def get_major(version_obj):
+    return version_obj.major
 
-def get_minor(version):
-    return version.version[1]
+def get_minor(version_obj):
+    return version_obj.minor
 
-def get_patch(version):
-    return version.version[2]
+def get_patch(version_obj):
+    return version_obj.micro
 
 def get_highest_minor_matching_major(versions_list, major):
     all_majors = [get_major(v) for v in versions_list]

--- a/hooks/expand-major-only.py
+++ b/hooks/expand-major-only.py
@@ -4,11 +4,31 @@ import sys
 import urllib.request
 
 class SimpleVersion:
-    """Simple version class using only standard library"""
+    """
+    A simple version class using only the Python standard library.
+
+    This class is intended as a minimal replacement for standard library components
+    such as distutils.version.StrictVersion, supporting only a subset of versioning features.
+
+    Supported version format:
+        - Version strings must be in the form "X.Y.Z", where X, Y, and Z are integers.
+        - Example: "1.9.3"
+        - No support for pre-releases, post-releases, alpha/beta/rc tags, or other PEP 440 features.
+
+    Comparison behavior:
+        - Versions are compared lexicographically by (major, minor, micro) components.
+        - Only equality and less-than comparisons are implemented.
+
+    Limitations:
+        - Only the "X.Y.Z" format is accepted; other formats will raise ValueError.
+        - Does not support version strings with fewer or more than three components.
+        - Does not support non-numeric version parts.
+        - Not a drop-in replacement for distutils.version.StrictVersion or packaging.version.Version.
+    """
     def __init__(self, version_string):
         self.version_string = version_string
         # Parse version string like "1.9.3" into components
-        match = re.match(r'^(\d+)\.(\d+)\.(\d+)', version_string)
+        match = re.match(r'^(\d+)\.(\d+)\.(\d+)$', version_string)
         if not match:
             raise ValueError(f"Invalid version string: {version_string}")
         self.major = int(match.group(1))
@@ -16,9 +36,13 @@ class SimpleVersion:
         self.micro = int(match.group(3))
     
     def __lt__(self, other):
+        if not isinstance(other, SimpleVersion):
+            return NotImplemented
         return (self.major, self.minor, self.micro) < (other.major, other.minor, other.micro)
     
     def __eq__(self, other):
+        if not isinstance(other, SimpleVersion):
+            return NotImplemented
         return (self.major, self.minor, self.micro) == (other.major, other.minor, other.micro)
     
     def __str__(self):


### PR DESCRIPTION
Fixes
```
  | Downloading Julia 1 for arch arm64
  | Traceback (most recent call last):
  | File "/private/var/tmp/agent-tempdirs/default-honeycrisp-HL2F7YQ3XH.0/home/.buildkite-agent/plugins/default-honeycrisp-HL2F7YQ3XH.0/github-com-JuliaCI-julia-buildkite-plugin-v1/hooks/expand-major-only.py", line 1, in <module>
  | import distutils.version
  | ModuleNotFoundError: No module named 'distutils'
```
https://buildkite.com/julialang/julia-buildkite-scheduled/builds/1374#01987d39-7726-4293-8218-2da1a728a37b/717-718


The standard recommendation is to update
1. Import Statement:
Old: `import distutils.version` (removed in Python 3.12)
New: `from packaging import version` (modern replacement)
2. Version Object Creation:
Old: `distutils.version.StrictVersion(s)`
New: `version.Version(s)`
3. Version Component Access:
Old: `version.version[0], version.version[1], version.version[2]` (accessing tuple elements)
New: v`ersion_obj.major, version_obj.minor, version_obj.micro` (using properties)

But the internet told me that `packaging` isn't a python stdlib, and isn't guaranteed to come preinstalled in `pip` (python is weird).

So it seemed simpler to just roll our own version parser?