### PR TITLE
support for alpha, beta, rc

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -33,7 +33,7 @@ steps:
 
       # Launch Linux jobs
       AGENT_OS="linux"
-      upload_pipelines x86_64  "1 1.10 nightly"
+      upload_pipelines x86_64  "1 1.10 nightly alpha beta rc"
       upload_pipelines i686    "1 nightly"
       upload_pipelines aarch64 "1 nightly"
 

--- a/.buildkite/run_tests.yml
+++ b/.buildkite/run_tests.yml
@@ -2,7 +2,7 @@ self_test_setup: &self_test_setup
   post-checkout: |
     mkdir -p .buildkite/plugins/julia
     cp -Ra hooks plugin.yml README.md .buildkite/plugins/julia/
-  
+
 steps:
   - label: ":julia: ${AGENT_OS?} ${ARCH?} ${JULIA_VERSION?}"
     agents:
@@ -20,6 +20,8 @@ steps:
       CHECK_VERSION="${JULIA_VERSION?}"
       if [[ "${JULIA_VERSION?}" == "nightly" ]]; then
         CHECK_VERSION="1."
+      elif [[ "${JULIA_VERSION?}" =~ ^(alpha|beta|rc)$ ]]; then
+        CHECK_VERSION="$$(python3 .buildkite/plugins/julia/hooks/named-versions-only.py "${JULIA_VERSION?}")"
       fi
       [[ "$$(julia --version)" == "julia version $${CHECK_VERSION}"* ]]
 

--- a/.buildkite/run_tests.yml
+++ b/.buildkite/run_tests.yml
@@ -16,12 +16,10 @@ steps:
           version: "${JULIA_VERSION?}"
           debug_plugin: "true"
     commands: |
-      # If we asked for a nightly version, just check that we got a `1.X`:
+      # If we asked for a nightly or prerelease version, just check that we got a `1.X`:
       CHECK_VERSION="${JULIA_VERSION?}"
-      if [[ "${JULIA_VERSION?}" == "nightly" ]]; then
+      if [[ "${JULIA_VERSION?}" =~ "^(alpha|beta|rc|nightly)$" ]]; then
         CHECK_VERSION="1."
-      elif [[ "${JULIA_VERSION?}" =~ ^(alpha|beta|rc)$ ]]; then
-        CHECK_VERSION="$$(python3 .buildkite/plugins/julia/hooks/named-versions-only.py "${JULIA_VERSION?}")"
       fi
       [[ "$$(julia --version)" == "julia version $${CHECK_VERSION}"* ]]
 

--- a/.buildkite/run_tests_windows32.yml
+++ b/.buildkite/run_tests_windows32.yml
@@ -2,7 +2,7 @@ self_test_setup: &self_test_setup
   post-checkout: |
     mkdir -p .buildkite/plugins/julia
     cp -Ra hooks plugin.yml README.md .buildkite/plugins/julia/
-  
+
 steps:
   - label: ":julia: ${AGENT_OS?} ${ARCH?} ${JULIA_VERSION?}"
     agents:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ steps:
 ## Options
 
 * `version`: A version to download and use, examples are `1`, `1.6`, `1.5.3`,
-  `1.7-nightly`.
+  `1.7-nightly`, `alpha`, `beta`, `rc`, or `1.13.0-beta3`.
+  The named prerelease channels resolve to the newest admissible Julia release.
 * `isolated_depot`: a boolean which defaults to `true`, automatically
   configuring Julia to use a pipeline-specific depot. If `false`, the default
   depot (usually `$HOME/.julia`) is used.

--- a/hooks/expand-major-only.py
+++ b/hooks/expand-major-only.py
@@ -34,17 +34,17 @@ class SimpleVersion:
         self.major = int(match.group(1))
         self.minor = int(match.group(2))
         self.micro = int(match.group(3))
-    
+
     def __lt__(self, other):
         if not isinstance(other, SimpleVersion):
             return NotImplemented
         return (self.major, self.minor, self.micro) < (other.major, other.minor, other.micro)
-    
+
     def __eq__(self, other):
         if not isinstance(other, SimpleVersion):
             return NotImplemented
         return (self.major, self.minor, self.micro) == (other.major, other.minor, other.micro)
-    
+
     def __str__(self):
         return self.version_string
 

--- a/hooks/named-versions-only.py
+++ b/hooks/named-versions-only.py
@@ -1,0 +1,127 @@
+import json
+import re
+import sys
+import urllib.request
+
+
+class SimpleVersion:
+    """
+    A simple Julia version parser using only the Python standard library.
+
+    Supported version formats:
+        - "X.Y.Z"
+        - "X.Y.Z-alphaN"
+        - "X.Y.Z-betaN"
+        - "X.Y.Z-rcN"
+
+    Comparison is done with three stable sorts:
+        1. suffix number
+        2. suffix kind
+        3. version number
+
+    This makes the version number the most important piece of information,
+    while still preferring stable releases over rcs, rcs over betas, and
+    betas over alphas when the numeric version is the same.
+    """
+
+    def __init__(self, version_string):
+        self.version_string = version_string
+        match = re.match(
+            r"^(\d+)\.(\d+)\.(\d+)(?:-(alpha|beta|rc)(\d+))?$",
+            version_string,
+        )
+        if not match:
+            raise ValueError(f"Invalid version string: {version_string}")
+
+        self.major = int(match.group(1))
+        self.minor = int(match.group(2))
+        self.micro = int(match.group(3))
+        self.suffix_kind = match.group(4)
+        self.suffix_number = int(match.group(5)) if match.group(5) else 0
+
+    def version_number_key(self):
+        return (self.major, self.minor, self.micro)
+
+    def suffix_kind_key(self):
+        if self.suffix_kind is None:
+            return 3
+        if self.suffix_kind == "rc":
+            return 2
+        if self.suffix_kind == "beta":
+            return 1
+        if self.suffix_kind == "alpha":
+            return 0
+        raise ValueError(f"Invalid suffix kind: {self.suffix_kind}")
+
+    def __str__(self):
+        return self.version_string
+
+
+def download_versions_json(url="https://julialang-s3.julialang.org/bin/versions.json"):
+    request = urllib.request.Request(url)
+    response = urllib.request.urlopen(request).read()
+    parsed_json = json.loads(response.decode("utf-8"))
+    return parsed_json
+
+
+def get_all_supported_versions(parsed_json):
+    versions = []
+    for version_string in parsed_json.keys():
+        try:
+            versions.append(SimpleVersion(version_string))
+        except ValueError:
+            continue
+    return versions
+
+
+def is_admissible(version_obj, requested_channel):
+    if requested_channel == "alpha":
+        return True
+    if requested_channel == "beta":
+        return version_obj.suffix_kind in (None, "rc", "beta")
+    if requested_channel == "rc":
+        return version_obj.suffix_kind in (None, "rc")
+    raise Exception("the named version must be one of: alpha, beta, rc")
+
+
+def order_versions_by_seniority(versions_list):
+    ordered_versions = list(versions_list)
+    ordered_versions.sort(key=lambda version: version.suffix_number)
+    ordered_versions.sort(key=lambda version: version.suffix_kind_key())
+    ordered_versions.sort(key=lambda version: version.version_number_key())
+    return ordered_versions
+
+
+def select_latest_named_version(parsed_json, requested_channel):
+    versions = get_all_supported_versions(parsed_json)
+    admissible_versions = [
+        version for version in versions if is_admissible(version, requested_channel)
+    ]
+    if not admissible_versions:
+        raise Exception("could not find a release matching the requested named version")
+
+    ordered_versions = order_versions_by_seniority(admissible_versions)
+    return ordered_versions[-1]
+
+
+def _main(requested_channel):
+    if requested_channel not in ("alpha", "beta", "rc"):
+        raise Exception("the named version must be one of: alpha, beta, rc")
+    parsed_json = download_versions_json()
+    selected_version = select_latest_named_version(parsed_json, requested_channel)
+    return selected_version
+
+
+def main():
+    if len(sys.argv) < 2:
+        raise Exception(
+            "the named version must be passed as the first positional command line argument"
+        )
+    requested_channel = sys.argv[1]
+    selected_version = _main(requested_channel)
+    print(selected_version)
+    return None
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -243,11 +243,15 @@ else
     # Minor version URLs contain `-latest` in their URLs
     postfix="-latest"
     if [[ $JULIA_VERSION =~ ^-?[0-9]+$ ]]; then     # for example, `version: '1'` or `version: '234'`
-        release="$("${PYTHON}" $(dirname $BASH_SOURCE)/expand-major-only.py "${JULIA_VERSION}")"
+        release="$("${PYTHON}" "$(dirname "$BASH_SOURCE")/expand-major-only.py" "${JULIA_VERSION}")"
+    elif [[ $JULIA_VERSION =~ ^(alpha|beta|rc)$ ]]; then
+        release="$("${PYTHON}" "$(dirname "$BASH_SOURCE")/named-versions-only.py" "${JULIA_VERSION}")"
+        # Named versions resolve to an exact release, so they do not use `-latest`.
+        postfix=""
     elif [[ $JULIA_VERSION =~ ^-?[0-9]+\.[0-9]+$ ]]; then
         release="${JULIA_VERSION}"                  # for example, `version: '123.456'`
-    elif [[ $JULIA_VERSION =~ ^-?[0-9]+(\.[0-9]+){2}$ ]]; then
-        release="${JULIA_VERSION}"                  # for example, `version: '1.2.3'`
+    elif [[ $JULIA_VERSION =~ ^-?[0-9]+(\.[0-9]+){2}(-(alpha|beta|rc)[0-9]+)?$ ]]; then
+        release="${JULIA_VERSION}"                  # for example, `version: '1.2.3'` or `version: '1.2.3-rc1'`
         # Exact versions do _not_ contain `-latest` in their URL
         postfix=""
     else


### PR DESCRIPTION
Add support for alpha, beta, rc

- alpha means "the latest release, or alpha, or beta, or rc"
- beta means "the latest release, or beta, or rc"
- rc means "the latest release or rc"

It is done with some code duplication in a new dedicated python helper script. The duplication is on purpose -- I wanted to avoid touching already battle-tested code.

Vibecoded with codex 5.4 but verified by me afterwards. Already in use for QuantumSavory.jl and QuantumSymbolics.jl